### PR TITLE
Update for Stardew Valley 1.3 & enable update checks

### DIFF
--- a/LovedLabels/LovedLabels.cs
+++ b/LovedLabels/LovedLabels.cs
@@ -54,7 +54,7 @@ namespace LovedLabels
         /// <param name="e">The event arguments.</param>
         private void Event_UpdateTick(object sender, EventArgs e)
         {
-            if (!Context.IsPlayerFree || !Game1.currentLocation.isFarm)
+            if (!Context.IsPlayerFree || !Game1.currentLocation.IsFarm)
                 return;
 
             // reset tooltip
@@ -68,18 +68,18 @@ namespace LovedLabels
             {
                 // find animals
                 FarmAnimal[] animals = new FarmAnimal[0];
-                if (location is AnimalHouse)
-                    animals = ((AnimalHouse)location).animals.Values.ToArray();
-                else if (location is Farm)
-                    animals = ((Farm)location).animals.Values.ToArray();
+                if (location is AnimalHouse house)
+                    animals = house.animals.Values.ToArray();
+                else if (location is Farm farm)
+                    animals = farm.animals.Values.ToArray();
 
                 // show tooltip
                 foreach (FarmAnimal animal in animals)
                 {
                     // Following values could use tweaking, no idea wtf is going on here
-                    RectangleF animalBoundaries = new RectangleF(animal.position.X, animal.position.Y - animal.sprite.getHeight(), animal.sprite.getWidth() * 3 + animal.sprite.getWidth() / 1.5f, animal.sprite.getHeight() * 4);
+                    RectangleF animalBoundaries = new RectangleF(animal.position.X, animal.position.Y - animal.Sprite.getHeight(), animal.Sprite.getWidth() * 3 + animal.Sprite.getWidth() / 1.5f, animal.Sprite.getHeight() * 4);
                     if (animalBoundaries.Contains(mousePos.X * Game1.tileSize, mousePos.Y * Game1.tileSize))
-                        this.HoverText = animal.wasPet ? this.Config.AlreadyPettedLabel : this.Config.NeedsToBePettedLabel;
+                        this.HoverText = animal.wasPet.Value ? this.Config.AlreadyPettedLabel : this.Config.NeedsToBePettedLabel;
                 }
             }
 
@@ -87,11 +87,11 @@ namespace LovedLabels
             foreach (Pet pet in location.characters.OfType<Pet>())
             {
                 // Following values could use tweaking, no idea wtf is going on here
-                RectangleF petBoundaries = new RectangleF(pet.position.X, pet.position.Y - pet.sprite.getHeight() * 2, pet.sprite.getWidth() * 3 + pet.sprite.getWidth() / 1.5f, pet.sprite.getHeight() * 4);
+                RectangleF petBoundaries = new RectangleF(pet.position.X, pet.position.Y - pet.Sprite.getHeight() * 2, pet.Sprite.getWidth() * 3 + pet.Sprite.getWidth() / 1.5f, pet.Sprite.getHeight() * 4);
 
                 if (petBoundaries.Contains(mousePos.X * Game1.tileSize, mousePos.Y * Game1.tileSize))
                 {
-                    bool wasPet = this.Helper.Reflection.GetPrivateValue<bool>(pet, "wasPetToday");
+                    bool wasPet = this.Helper.Reflection.GetField<bool>(pet, "wasPetToday").GetValue();
                     this.HoverText = wasPet ? this.Config.AlreadyPettedLabel : this.Config.NeedsToBePettedLabel;
                 }
             }

--- a/LovedLabels/LovedLabels.csproj
+++ b/LovedLabels/LovedLabels.csproj
@@ -41,20 +41,21 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="manifest.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <None Include="manifest.json" />
     <None Include="hearts.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.6.2\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.6.2\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.6.2\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.6.2\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/LovedLabels/manifest.json
+++ b/LovedLabels/manifest.json
@@ -1,14 +1,10 @@
 ﻿{
   "Name": "LovedLabels",
   "Author": "Advize & Jinxiewinxie",
-  "Version": {
-    "MajorVersion": 2,
-    "MinorVersion": 1,
-    "PatchVersion": 0,
-    "Build": null
-  },
-  "MinimumApiVersion": "1.15",
+  "Version": "2.1.0",
   "Description": "Gives pets customizable tooltips so you can see who needs the love.",
   "UniqueID": "Advize.LovedLabels",
-  "EntryDll": "LovedLabels.dll"
+  "EntryDll": "LovedLabels.dll",
+  "MinimumApiVersion": "2.0",
+  "UpdateKeys": [ "Nexus:279" ]
 }

--- a/LovedLabels/manifest.json
+++ b/LovedLabels/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "Name": "LovedLabels",
   "Author": "Advize & Jinxiewinxie",
-  "Version": "2.1.0",
+  "Version": "2.2.0",
   "Description": "Gives pets customizable tooltips so you can see who needs the love.",
   "UniqueID": "Advize.LovedLabels",
   "EntryDll": "LovedLabels.dll",

--- a/LovedLabels/manifest.json
+++ b/LovedLabels/manifest.json
@@ -5,6 +5,6 @@
   "Description": "Gives pets customizable tooltips so you can see who needs the love.",
   "UniqueID": "Advize.LovedLabels",
   "EntryDll": "LovedLabels.dll",
-  "MinimumApiVersion": "2.0",
+  "MinimumApiVersion": "2.6-beta",
   "UpdateKeys": [ "Nexus:279" ]
 }

--- a/LovedLabels/packages.config
+++ b/LovedLabels/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.6.2" targetFramework="net452" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
This pull request...
* Updates the code for Stardew Valley 1.3 (including multiplayer support).
* Enables [update checks](https://stardewvalleywiki.com/Modding:SMAPI_APIs#Update_checks).
* Bumps the version for release and updates the manifest format.

If these changes look fine, can you release [LovedLabels 2.2.zip](https://github.com/AdvizeGH/LovedLabels/files/1953553/LovedLabels.2.2.zip) to the [Nexus mod page](https://www.nexusmods.com/stardewvalley/mods/279)? (This version isn't compatible with Stardew Valley 1.2, so I suggest keeping the old version too for players who haven't updated yet.)